### PR TITLE
Fix pagination

### DIFF
--- a/src/collective/fieldcollapsing/behaviors.py
+++ b/src/collective/fieldcollapsing/behaviors.py
@@ -44,11 +44,27 @@ class ICollectionFieldCollapser(model.Schema):
             u"Select the field, which the results will collapse on and return "
             u"the first of each collapsed set")
     )
-    directives.order_after(collapse_on='ICollection.query')
     directives.widget(
         'collapse_on',
         SelectFieldWidget
     )
+
+    collapse_batch_multipler = schema.Int(
+        title=_(u"Collapse Batch"),
+        required=False,
+        default=3,
+        description=_(
+            u"Collapse the total number of pages by the given integer to fill "
+            u"up the page. For instance, if each page suppose to show 30 "
+            u"items and there are 18 pages, which have up to 8 items, then "
+            u"fill up the page from other pages based on the given number of "
+            u"collapsed pages. As a result, if the given number of collapsed "
+            u"pages is 2, then there will be a total of 9 pages instead of 18 "
+            u"pages with 30 items if applicable."
+        )
+    )
+    directives.order_after(collapse_batch_multipler='ICollection.query')
+    directives.order_after(collapse_on='ICollection.query')
 
 
 @implementer(ICollectionFieldCollapser)
@@ -64,3 +80,11 @@ class CollectionFieldCollapserFactory(object):
     @collapse_on.setter
     def collapse_on(self, value):
         self.context.collapse_on = value
+
+    @property
+    def collapse_batch_multipler(self):
+        return getattr(self.context, 'collapse_batch_multipler', 3)
+
+    @collapse_batch_multipler.setter
+    def collapse_batch_multipler(self, value):
+        self.context.collapse_batch_multipler = value

--- a/src/collective/fieldcollapsing/behaviors.py
+++ b/src/collective/fieldcollapsing/behaviors.py
@@ -49,13 +49,14 @@ class ICollectionFieldCollapser(model.Schema):
         SelectFieldWidget
     )
 
-    collapse_batch_multipler = schema.Int(
+    collapse_batch_multiplier = schema.Int(
         title=_(u"Collapse Batch"),
         required=False,
         default=3,
         description=_(
-            u"Collapse the total number of pages by the given integer to fill "
-            u"up the page. For instance, if each page suppose to show 30 "
+            u"Collapse the total number of pages by the given integer to "
+            u"ensure that the number of items on each page is close to the "
+            u"given item count. For instance, if each page suppose to show 30 "
             u"items and there are 18 pages, which have up to 8 items, then "
             u"fill up the page from other pages based on the given number of "
             u"collapsed pages. As a result, if the given number of collapsed "
@@ -63,7 +64,7 @@ class ICollectionFieldCollapser(model.Schema):
             u"pages with 30 items if applicable."
         )
     )
-    directives.order_after(collapse_batch_multipler='ICollection.query')
+    directives.order_after(collapse_batch_multiplier='ICollection.query')
     directives.order_after(collapse_on='ICollection.query')
 
 
@@ -82,9 +83,9 @@ class CollectionFieldCollapserFactory(object):
         self.context.collapse_on = value
 
     @property
-    def collapse_batch_multipler(self):
-        return getattr(self.context, 'collapse_batch_multipler', 3)
+    def collapse_batch_multiplier(self):
+        return getattr(self.context, 'collapse_batch_multiplier', 3)
 
-    @collapse_batch_multipler.setter
-    def collapse_batch_multipler(self, value):
-        self.context.collapse_batch_multipler = value
+    @collapse_batch_multiplier.setter
+    def collapse_batch_multiplier(self, value):
+        self.context.collapse_batch_multiplier = value

--- a/src/collective/fieldcollapsing/browser/querybuilder.py
+++ b/src/collective/fieldcollapsing/browser/querybuilder.py
@@ -172,14 +172,14 @@ class QueryBuilder(BaseQueryBuilder):
                 collapsed_result_count = (
                     results.actual_result_count 
                 )
-                collapse_batch_multipler = self.request.get(
-                    'collapse_batch_multipler',
-                    getattr(self.context, 'collapse_batch_multipler', 3)
+                collapse_batch_multiplier = self.request.get(
+                    'collapse_batch_multiplier',
+                    getattr(self.context, 'collapse_batch_multiplier', 3)
                 ) + 1
                 if collapsed_results.actual_result_count < b_size:
-                    for i in range(0, collapse_batch_multipler  - 1):
+                    for i in range(0, collapse_batch_multiplier  - 1):
                         if collapsed_results.actual_result_count >= b_size:
-                            collapse_batch_multipler -= 1
+                            collapse_batch_multiplier -= 1
                             break
                         parsedquery['b_start'] = \
                             parsedquery.get('b_start', 0) + b_size
@@ -188,7 +188,7 @@ class QueryBuilder(BaseQueryBuilder):
                                 self._makesubquery(parsedquery, limit),
                                 test=fc.collapse
                             )
-                    b_size = (b_size * collapse_batch_multipler)
+                    b_size = (b_size * collapse_batch_multiplier)
 
                 if type(results).__name__ == 'LazyCat':
                     results = LazyCat(

--- a/src/collective/fieldcollapsing/browser/querybuilder.py
+++ b/src/collective/fieldcollapsing/browser/querybuilder.py
@@ -175,10 +175,11 @@ class QueryBuilder(BaseQueryBuilder):
                 collapse_batch_multipler = self.request.get(
                     'collapse_batch_multipler',
                     getattr(self.context, 'collapse_batch_multipler', 3)
-                )
+                ) + 1
                 if collapsed_results.actual_result_count < b_size:
-                    for i in range(0, collapse_batch_multipler):
+                    for i in range(0, collapse_batch_multipler  - 1):
                         if collapsed_results.actual_result_count >= b_size:
+                            collapse_batch_multipler -= 1
                             break
                         parsedquery['b_start'] = \
                             parsedquery.get('b_start', 0) + b_size
@@ -187,7 +188,7 @@ class QueryBuilder(BaseQueryBuilder):
                                 self._makesubquery(parsedquery, limit),
                                 test=fc.collapse
                             )
-                    b_size = b_size * collapse_batch_multipler
+                    b_size = (b_size * collapse_batch_multipler)
 
                 if type(results).__name__ == 'LazyCat':
                     results = LazyCat(

--- a/src/collective/fieldcollapsing/browser/querybuilder.py
+++ b/src/collective/fieldcollapsing/browser/querybuilder.py
@@ -182,11 +182,13 @@ class QueryBuilder(BaseQueryBuilder):
                             break
                         parsedquery['b_start'] = \
                             parsedquery.get('b_start', 0) + b_size
-                        results = self._makesubquery(parsedquery, limit)
                         collapsed_results += \
-                            LazyFilter(results, test=fc.collapse)
+                            LazyFilter(
+                                self._makesubquery(parsedquery, limit),
+                                test=fc.collapse
+                            )
                     b_size = b_size * collapse_batch_multipler
-                
+
                 if type(results).__name__ == 'LazyCat':
                     results = LazyCat(
                         collapsed_results,

--- a/src/collective/fieldcollapsing/tests/testQueryBuilder.py
+++ b/src/collective/fieldcollapsing/tests/testQueryBuilder.py
@@ -77,7 +77,7 @@ class TestQuerybuilder(unittest.TestCase):
             brains=True,
             sort_on="created"
         )
-        self.assertEqual(len(results), self.total_num_docs)
+        self.assertEqual(len(results), self.num_folders)
         self.assertEqual(
             results[0].getURL(),
             'http://nohost/plone/testfolder-1/testpage-1')
@@ -95,7 +95,7 @@ class TestQuerybuilder(unittest.TestCase):
             brains=True,
             sort_on="created"
         )
-        self.assertEqual(len(results), self.total_num_docs)
+        self.assertEqual(len(results), self.num_folders)
         self.assertEqual(
             results[0].getURL(),
             'http://nohost/plone/testfolder-1/testpage-1')
@@ -162,7 +162,7 @@ class TestQuerybuilder(unittest.TestCase):
         )
         
         # Test the reported length of the collapsed results
-        self.assertEqual(len(collasped_results), self.total_num_docs)
+        self.assertEqual(len(collasped_results), self.num_folders)
         # Test the reported length of the collapsed results
         # aganist the actual length of the collapsed results
         self.assertNotEqual(
@@ -202,7 +202,7 @@ class TestQuerybuilder(unittest.TestCase):
             custom_query={"collapse_on": "Subject"},
             sort_on="created"
         )
-        self.assertEqual(len(results), self.total_num_docs)
+        self.assertEqual(len(results), self.num_folders)
         self.assertEqual(len(results[:]), self.num_folders)
         self.assertEqual(
             results[0].getURL(),
@@ -225,7 +225,7 @@ class TestQuerybuilder(unittest.TestCase):
             custom_query={"collapse_on": "Subject"},
             sort_on="created"
         )
-        self.assertEqual(len(results), self.total_num_docs)
+        self.assertEqual(len(results), self.num_folders)
         self.assertEqual(len(results[:]), self.num_folders)
         self.assertEqual(
             results[0].getURL(),


### PR DESCRIPTION
Collapse the total number of pages by the given integer to fill up the page. For instance, if each page suppose to show 30 items and there are 18 pages, which have up to 8 items, then fill up the page from other pages based on the given number of collapsed pages. As a result, if the given number of collapsed pages is 3, then there will be a total of 6 pages instead of 18 with 30 items if applicable.