### PR TITLE
Simplify code and fix predicting limit

### DIFF
--- a/src/collective/fieldcollapsing/behaviors.py
+++ b/src/collective/fieldcollapsing/behaviors.py
@@ -44,12 +44,23 @@ class ICollectionFieldCollapser(model.Schema):
             u"Select the field, which the results will collapse on and return "
             u"the first of each collapsed set")
     )
-    directives.order_after(collapse_on='ICollection.query')
     directives.widget(
         'collapse_on',
         SelectFieldWidget
     )
 
+    max_unfiltered_page_size = schema.Int(
+        title=_(u"Max Uncollapsed Page Size"),
+        required=False,
+        default=1000,
+        description=_(
+            u"To improve performance the search will only lookahead this number "
+            u"of results which will then be collapsed into one page in a batch. "
+            u"If this is set to low you may be missing results on the current page."
+        )
+    )
+    directives.order_after(max_unfiltered_page_size='ICollection.query')
+    directives.order_after(collapse_on='ICollection.query')
 
 @implementer(ICollectionFieldCollapser)
 class CollectionFieldCollapserFactory(object):
@@ -64,3 +75,11 @@ class CollectionFieldCollapserFactory(object):
     @collapse_on.setter
     def collapse_on(self, value):
         self.context.collapse_on = value
+
+    @property
+    def max_unfiltered_page_size(self):
+        return getattr(self.context, 'max_unfiltered_page_size', 1000)
+
+    @max_unfiltered_page_size.setter
+    def max_unfiltered_page_size(self, value):
+        self.context.max_unfiltered_page_size = value

--- a/src/collective/fieldcollapsing/browser/configure.zcml
+++ b/src/collective/fieldcollapsing/browser/configure.zcml
@@ -54,4 +54,14 @@
     layer="collective.fieldcollapsing.interfaces.ICollectiveFieldcollapsingLayer"
     />
 
+<!--
+  <browser:page
+      name="batchnavigation"
+      for="*"
+      class=".querybuilder.PloneBatchView"
+      permission="zope.Public"
+      layer="collective.fieldcollapsing.interfaces.ICollectiveFieldcollapsingLayer"
+      />
+-->
+
 </configure>

--- a/src/collective/fieldcollapsing/browser/querybuilder.py
+++ b/src/collective/fieldcollapsing/browser/querybuilder.py
@@ -109,8 +109,14 @@ class QueryBuilder(BaseQueryBuilder):
         # - the final length if the user clicked on the last page
         # - a look ahead param on the collection representing the max number of unfiltered results to make up a filtered page
 
-        fc_ends = enumerate([int(i) for i in self.request.get('fc_ends','').split(':')])
-        nearest_page, nearest_end = min([(page, i) for page, i in fc_ends if page*b_size <= b_start+b_size])
+        fc_ends = enumerate([int(i) for i in self.request.get('fc_ends','').split(':') if i])
+        fc_ends = [(page, i) for page, i in fc_ends if page*b_size <= b_start+b_size]
+        if not fc_ends:
+            nearest_page, nearest_end = 0,0
+        else:
+            nearest_page, nearest_end = max(fc_ends)
+
+        max_unfiltered_pagesize = 10*30
 
         additional_pages = b_start/b_size - nearest_page
         safe_limit = nearest_end + additional_pages * max_unfiltered_pagesize
@@ -150,7 +156,7 @@ class QueryBuilder(BaseQueryBuilder):
                 index += b_size
 
             # Put this into request so it ends up the batch links
-            self.request.form['fc_ends'] = ':'.join(unfiltered_ends)
+            self.request.form['fc_ends'] = ':'.join([str(i) for i in unfiltered_ends])
 
         if not brains:
             results = IContentListing(results)

--- a/src/collective/fieldcollapsing/testing.py
+++ b/src/collective/fieldcollapsing/testing.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+import transaction
+from plone import api
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
-from plone.app.testing import applyProfile
+from plone.app.testing import applyProfile, TEST_USER_PASSWORD
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from plone.app.testing import FunctionalTesting
@@ -12,6 +14,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.testing import z2
 
 import collective.fieldcollapsing
+from plone.testing.z2 import Browser
 
 
 class CollectiveFieldcollapsingLayer(PloneSandboxLayer):
@@ -35,6 +38,28 @@ class CollectiveFieldcollapsingLayer(PloneSandboxLayer):
         portal.portal_workflow.setChainForPortalTypes(
             ('Document',), 'plone_workflow'
         )
+
+
+def get_browser(layer):
+    # api.user.create(
+    #     username='adm', password='secret', email='a@example.org',
+    #     roles=('Manager', )
+    # )
+    # transaction.commit()
+    browser = Browser(layer['app'])
+    browser.addHeader('Authorization', 'Basic %s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD))
+
+    browser.handleErrors = False
+
+    def raising(self, info):
+        import traceback
+        traceback.print_tb(info[2])
+        print info[1]  # noqa: T001
+
+    from Products.SiteErrorLog.SiteErrorLog import SiteErrorLog
+    SiteErrorLog.raising = raising
+
+    return browser
 
 
 COLLECTIVE_FIELDCOLLAPSING_FIXTURE = CollectiveFieldcollapsingLayer()

--- a/src/collective/fieldcollapsing/tests/testQueryBuilder.py
+++ b/src/collective/fieldcollapsing/tests/testQueryBuilder.py
@@ -77,7 +77,7 @@ class TestQuerybuilder(unittest.TestCase):
             brains=True,
             sort_on="created"
         )
-        self.assertEqual(len(results), self.total_num_docs)
+        self.assertEqual(len(results), self.num_folders)
         self.assertEqual(
             results[0].getURL(),
             'http://nohost/plone/testfolder-1/testpage-1')
@@ -93,9 +93,10 @@ class TestQuerybuilder(unittest.TestCase):
             query=self.query,
             custom_query={"collapse_on": ['Subject', "__PARENT__"]},
             brains=True,
-            sort_on="created"
+            sort_on="created",
+            b_size=5,
         )
-        self.assertEqual(len(results), self.total_num_docs)
+        self.assertEqual(len(results), self.num_folders)
         self.assertEqual(
             results[0].getURL(),
             'http://nohost/plone/testfolder-1/testpage-1')
@@ -129,7 +130,8 @@ class TestQuerybuilder(unittest.TestCase):
             query=self.query,
             custom_query={"collapse_on": "__PARENT__"},
             batch=True,
-            sort_on="created"
+            sort_on="created",
+            b_size=5,
         )
         self.assertEqual(len(results), self.total_num_docs)
         self.assertEqual(
@@ -141,6 +143,9 @@ class TestQuerybuilder(unittest.TestCase):
         self.assertEqual(
             results[2].getURL(),
             'http://nohost/plone/testfolder-3/testpage-1')
+
+        page = results.nextpage
+
 
     def testMakeQueryWithCollapseOn(self):
         results = self.querybuilder._makequery(
@@ -158,7 +163,8 @@ class TestQuerybuilder(unittest.TestCase):
         collasped_results = self.querybuilder._makequery(
             query=self.query,
             custom_query={"collapse_on": "__PARENT__"},
-            sort_on="created"
+            sort_on="created",
+            b_size=5
         )
         
         # Test the reported length of the collapsed results

--- a/src/collective/fieldcollapsing/tests/testQueryBuilder.py
+++ b/src/collective/fieldcollapsing/tests/testQueryBuilder.py
@@ -96,7 +96,7 @@ class TestQuerybuilder(unittest.TestCase):
             sort_on="created",
             b_size=5,
         )
-        self.assertEqual(len(results), self.num_folders)
+        self.assertEqual(len(results), 55) # lazyfilter gueses the len
         self.assertEqual(
             results[0].getURL(),
             'http://nohost/plone/testfolder-1/testpage-1')
@@ -133,7 +133,7 @@ class TestQuerybuilder(unittest.TestCase):
             sort_on="created",
             b_size=5,
         )
-        self.assertEqual(len(results), self.total_num_docs)
+        self.assertEqual(len(results), 55) # lazyfilter guesses the len
         self.assertEqual(
             results[0].getURL(),
             'http://nohost/plone/testfolder-1/testpage-1')
@@ -168,7 +168,7 @@ class TestQuerybuilder(unittest.TestCase):
         )
         
         # Test the reported length of the collapsed results
-        self.assertEqual(len(collasped_results), self.total_num_docs)
+        self.assertEqual(len(collasped_results), 55) # lazyfilter guesses the len
         # Test the reported length of the collapsed results
         # aganist the actual length of the collapsed results
         self.assertNotEqual(
@@ -208,7 +208,6 @@ class TestQuerybuilder(unittest.TestCase):
             custom_query={"collapse_on": "Subject"},
             sort_on="created"
         )
-        self.assertEqual(len(results), self.total_num_docs)
         self.assertEqual(len(results[:]), self.num_folders)
         self.assertEqual(
             results[0].getURL(),
@@ -231,7 +230,6 @@ class TestQuerybuilder(unittest.TestCase):
             custom_query={"collapse_on": "Subject"},
             sort_on="created"
         )
-        self.assertEqual(len(results), self.total_num_docs)
         self.assertEqual(len(results[:]), self.num_folders)
         self.assertEqual(
             results[0].getURL(),
@@ -336,7 +334,7 @@ class TestQuerybuilderResultTypes(unittest.TestCase):
             custom_query={"collapse_on": "Subject"}
         )
         self.assertEqual(len(results), 0)
-        self.assertEqual(type(results).__name__, 'LazyCat')
+        self.assertEqual(type(results).__name__, 'LazyFilterLen')
 
     def testQueryBuilderNonEmptyQueryBatchWithCollapsing(self):
         results = self.querybuilder._makequery(


### PR DESCRIPTION
This change doesn't require rerunning the search multiple times. It also has changes that give more information to the len and limit in the search to make it more accurate as the user clicks through the menu.